### PR TITLE
Templates for default formatter

### DIFF
--- a/formatters/default_test.go
+++ b/formatters/default_test.go
@@ -28,7 +28,7 @@ func TestPartialFields(t *testing.T) {
 }
 
 func BenchmarkFormatter(b *testing.B) {
-	formatter := formatters.NewDefaultFormatter("<_logLevel_> <_callLocation_> <_dateTime_>: _message_", formatters.DefaultTimeLayout)
+	formatter := formatters.NewDefaultFormatter("<{{.LogLevel}}> <{{.CallLocation}}> <{{.DateTime}}>: {{.Message}}", formatters.DefaultTimeLayout)
 	tm, _ := time.Parse("2006-01-02 15:04:05 GMT-0700", "2006-01-02 15:04:05 GMT-0700")
 
 	b.ResetTimer()

--- a/formatters/default_test.go
+++ b/formatters/default_test.go
@@ -10,10 +10,29 @@ import (
 )
 
 func TestDefaultFormatter(t *testing.T) {
-	formatter := formatters.NewDefaultFormatter("<_logLevel_> <_callLocation_> <_dateTime_>: _message_", formatters.DefaultTimeLayout)
+	formatter := formatters.NewDefaultFormatter("<{{.LogLevel}}> <{{.CallLocation}}> <{{.DateTime}}>: {{.Message}}", formatters.DefaultTimeLayout)
 
 	tm, _ := time.Parse("2006-01-02 15:04:05 GMT-0700", "2006-01-02 15:04:05 GMT-0700")
 	got := formatter.Format(logman.Debug, tm, "fake call location", "debug message")
 
 	testutils.AssertEqual(t, got, "<Debug> <fake call location> <2006-01-02 15:04:05 GMT-0700>: debug message")
+}
+
+func TestPartialFields(t *testing.T) {
+	formatter := formatters.NewDefaultFormatter("<{{.LogLevel}}> <{{.DateTime}}>: {{.Message}}", formatters.DefaultTimeLayout)
+
+	tm, _ := time.Parse("2006-01-02 15:04:05 GMT-0700", "2006-01-02 15:04:05 GMT-0700")
+	got := formatter.Format(logman.Debug, tm, "fake call location", "debug message")
+
+	testutils.AssertEqual(t, got, "<Debug> <2006-01-02 15:04:05 GMT-0700>: debug message")
+}
+
+func BenchmarkFormatter(b *testing.B) {
+	formatter := formatters.NewDefaultFormatter("<_logLevel_> <_callLocation_> <_dateTime_>: _message_", formatters.DefaultTimeLayout)
+	tm, _ := time.Parse("2006-01-02 15:04:05 GMT-0700", "2006-01-02 15:04:05 GMT-0700")
+
+	b.ResetTimer()
+	for range b.N {
+		formatter.Format(logman.Debug, tm, "fake call location", "debug message")
+	}
 }

--- a/formatters/default_test.go
+++ b/formatters/default_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestDefaultFormatter(t *testing.T) {
-	formatter := formatters.NewDefaultFormatter("<{{.LogLevel}}> <{{.CallLocation}}> <{{.DateTime}}>: {{.Message}}", formatters.DefaultTimeLayout)
+	formatter := formatters.NewDefaultFormatter("<_logLevel_> <_callLocation_> <_dateTime_>: _message_", formatters.DefaultTimeLayout)
 
 	tm, _ := time.Parse("2006-01-02 15:04:05 GMT-0700", "2006-01-02 15:04:05 GMT-0700")
 	got := formatter.Format(logman.Debug, tm, "fake call location", "debug message")
@@ -19,7 +19,7 @@ func TestDefaultFormatter(t *testing.T) {
 }
 
 func TestPartialFields(t *testing.T) {
-	formatter := formatters.NewDefaultFormatter("<{{.LogLevel}}> <{{.DateTime}}>: {{.Message}}", formatters.DefaultTimeLayout)
+	formatter := formatters.NewDefaultFormatter("<_logLevel_> <_dateTime_>: _message_", formatters.DefaultTimeLayout)
 
 	tm, _ := time.Parse("2006-01-02 15:04:05 GMT-0700", "2006-01-02 15:04:05 GMT-0700")
 	got := formatter.Format(logman.Debug, tm, "fake call location", "debug message")
@@ -28,7 +28,7 @@ func TestPartialFields(t *testing.T) {
 }
 
 func BenchmarkFormatter(b *testing.B) {
-	formatter := formatters.NewDefaultFormatter("<{{.LogLevel}}> <{{.CallLocation}}> <{{.DateTime}}>: {{.Message}}", formatters.DefaultTimeLayout)
+	formatter := formatters.NewDefaultFormatter(formatters.DefaultFormat, formatters.DefaultTimeLayout)
 	tm, _ := time.Parse("2006-01-02 15:04:05 GMT-0700", "2006-01-02 15:04:05 GMT-0700")
 
 	b.ResetTimer()


### PR DESCRIPTION
Running benchmark like this

```shell
go test -benchmem -run=^$ -bench ^BenchmarkFormatter$ github.com/mishankov/logman/formatters
```

Old version results:

```
goos: windows
goarch: amd64
pkg: github.com/mishankov/logman/formatters
cpu: AMD Ryzen 7 5700G with Radeon Graphics         
BenchmarkFormatter-16    	 2935496	       411.0 ns/op	     320 B/op	       5 allocs/op
PASS
ok  	github.com/mishankov/logman/formatters	1.779s
```